### PR TITLE
Capture terminal output from Zellij for failed command context

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -46,12 +46,13 @@ type Response struct {
 
 // TashResponse is the structured JSON response from the AI.
 type TashResponse struct {
-	Type           string   `json:"type"`                      // "command", "chat", "history", "memory", "plan"
+	Type           string   `json:"type"`                      // "command", "chat", "history", "memory", "plan", "screen"
 	Commands       []string `json:"commands,omitempty"`        // for type "command" or "plan"
 	Message        string   `json:"message,omitempty"`         // explanation, chat text, or memory fact
 	Count          int      `json:"count,omitempty"`           // for type "history": how many entries
 	Filter         string   `json:"filter,omitempty"`          // for type "history": grep filter
 	StepsRemaining int      `json:"steps_remaining,omitempty"` // for type "plan": estimated remaining steps
+	Lines          int      `json:"lines,omitempty"`           // for type "screen": how many lines to capture
 }
 
 // NewClient creates an AI client from config.

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -40,6 +40,9 @@ Chat/explanation:
 Request more shell history to give a better answer. Use "filter" to search, "count" for last N entries:
 {"type": "history", "filter": "git", "count": 30}
 
+Request terminal screen output (Zellij pane scrollback). Use this when a command failed and you need to see the actual error output, or when the user references something visible on screen. "lines" controls how many lines from the bottom (default 20, max configured by user):
+{"type": "screen", "lines": 50}
+
 Store durable facts about the user (name, role, preferences, tech stack, workflows). Always follow a memory line with a chat or command line — the user won't see the memory action:
 {"type": "memory", "message": "User is John, backend engineer working on payment services in Go"}
 {"type": "chat", "message": "Hey John! What are you working on?"}

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -85,6 +85,7 @@ func TestSystemPrompt_ContainsKeyPhrases(t *testing.T) {
 		"history",
 		"memory",
 		"plan",
+		"screen",
 	}
 	for _, phrase := range phrases {
 		if !strings.Contains(SystemPrompt, phrase) {

--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -34,9 +34,11 @@ type ModelConfig struct {
 
 // BehaviorConfig holds runtime behavior settings.
 type BehaviorConfig struct {
-	MaxRetries    int  `yaml:"max_retries"`
-	MaxMemories   int  `yaml:"max_memories"`
-	AutoIntercept bool `yaml:"auto_intercept"`
+	MaxRetries            int  `yaml:"max_retries"`
+	MaxMemories           int  `yaml:"max_memories"`
+	AutoIntercept         bool `yaml:"auto_intercept"`
+	ScreenCapture         bool `yaml:"screen_capture"`
+	ScreenCaptureMaxLines int  `yaml:"screen_capture_max_lines"`
 }
 
 // ProfileConfig holds profile rebuild settings.
@@ -55,9 +57,11 @@ func DefaultConfig() *Config {
 			MaxTokens: 2048,
 		},
 		Behavior: BehaviorConfig{
-			MaxRetries:    3,
-			MaxMemories:   50,
-			AutoIntercept: true,
+			MaxRetries:            3,
+			MaxMemories:           50,
+			AutoIntercept:         true,
+			ScreenCapture:         true,
+			ScreenCaptureMaxLines: 200,
 		},
 		Theme: ThemeConfig{
 			Name: "solarized",

--- a/internal/data/config_test.go
+++ b/internal/data/config_test.go
@@ -30,6 +30,12 @@ func TestDefaultConfig(t *testing.T) {
 	if !cfg.Behavior.AutoIntercept {
 		t.Error("expected auto_intercept true")
 	}
+	if !cfg.Behavior.ScreenCapture {
+		t.Error("expected screen_capture true")
+	}
+	if cfg.Behavior.ScreenCaptureMaxLines != 200 {
+		t.Errorf("expected 200 screen_capture_max_lines, got %d", cfg.Behavior.ScreenCaptureMaxLines)
+	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("expected info, got %q", cfg.LogLevel)
 	}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -32,15 +32,22 @@ func Run(cfg *data.Config, prof *data.Profile, convo *data.Conversation, input s
 		"conversation_entries", len(convo.Entries),
 	)
 
-	// Build multi-turn messages from conversation history
-	messages := buildMessages(convo, shellHistory, input, nil)
+	// Inject initial screen context from Zellij (if available)
+	var initialConstraints []string
+	if screenCtx := initialScreenContext(cfg); screenCtx != "" {
+		initialConstraints = append(initialConstraints, screenCtx)
+		slog.Debug("initial screen context injected", "len", len(screenCtx))
+	}
 
-	// Attempt loop: tool calls (history, memory) don't count toward retries.
+	// Build multi-turn messages from conversation history
+	messages := buildMessages(convo, shellHistory, input, initialConstraints)
+
+	// Attempt loop: tool calls (history, memory, screen) don't count toward retries.
 	// Only real failures (API error, parse error, no terminal response) do.
 	// Tool calls are capped at 2 to prevent search loops.
 	const maxToolCalls = 2
 	var lastErr error
-	var constraints []string
+	constraints := append([]string{}, initialConstraints...)
 	failures := 0
 	toolCalls := 0
 	planStep := 0
@@ -131,7 +138,7 @@ func Run(cfg *data.Config, prof *data.Profile, convo *data.Conversation, input s
 		default:
 			slog.Warn("no terminal response", "attempt", attempt)
 			if toolCalls >= maxToolCalls {
-				constraints = append(constraints, "No more history lookups available. Respond with a command or chat based on what you already know.")
+				constraints = append(constraints, "No more tool calls available (history, screen). Respond with a command or chat based on what you already know.")
 			}
 			lastErr = fmt.Errorf("no chat or command in response")
 			failures++
@@ -183,6 +190,12 @@ func handleResponses(
 			constraint := searchContext(cfg, convo, shellHistory, parsed.Filter, parsed.Count)
 			*constraints = append(*constraints, constraint)
 			*retryReason = "Searching history"
+			retry = true
+		} else if parsed.Type == "screen" && !skipToolCalls {
+			slog.Debug("screen request", "lines", parsed.Lines)
+			constraint := captureScreen(cfg, parsed.Lines)
+			*constraints = append(*constraints, constraint)
+			*retryReason = "Reading terminal"
 			retry = true
 		}
 	}

--- a/internal/query/screen.go
+++ b/internal/query/screen.go
@@ -1,0 +1,162 @@
+package query
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/renjfk/tash/internal/data"
+)
+
+// ansiPattern matches ANSI escape sequences (CSI, OSC, and single-char escapes).
+var ansiPattern = regexp.MustCompile(`\x1b(?:\[[0-9;]*[a-zA-Z]|\][^\x07]*\x07|[()][0-9A-B]|[=>])`)
+
+// captureScreen runs zellij dump-screen and returns the parsed terminal output
+// as a constraint string. The lines parameter controls how many lines to return
+// from the bottom of the dump. If lines exceeds the visible screen, it escalates
+// to a full scrollback dump.
+func captureScreen(cfg *data.Config, lines int) string {
+	if !cfg.Behavior.ScreenCapture {
+		return "Screen capture is disabled"
+	}
+
+	if os.Getenv("ZELLIJ") == "" {
+		return "Not running inside Zellij — screen capture unavailable"
+	}
+
+	if lines <= 0 {
+		lines = 20
+	}
+
+	maxLines := cfg.Behavior.ScreenCaptureMaxLines
+	if maxLines <= 0 {
+		maxLines = 200
+	}
+	if lines > maxLines {
+		lines = maxLines
+	}
+
+	// First try visible screen dump
+	content, err := zellijDumpScreen(false)
+	if err != nil {
+		slog.Warn("zellij dump-screen failed", "error", err)
+		return fmt.Sprintf("Screen capture failed: %s", err)
+	}
+
+	parsed := parseScreenDump(content, lines)
+
+	// If requested lines exceed visible content, escalate to full scrollback
+	visibleLines := countNonEmpty(content)
+	if lines > visibleLines {
+		fullContent, err := zellijDumpScreen(true)
+		if err != nil {
+			slog.Warn("zellij dump-screen --full failed", "error", err)
+			// Fall back to the visible content we already have
+		} else {
+			parsed = parseScreenDump(fullContent, lines)
+		}
+	}
+
+	if parsed == "" {
+		return "Screen capture returned empty content"
+	}
+
+	return "Terminal screen output:\n" + parsed
+}
+
+// zellijDumpScreen runs zellij action dump-screen to a temp file and returns its contents.
+// If full is true, captures the full scrollback buffer.
+func zellijDumpScreen(full bool) (string, error) {
+	tmpFile, err := os.CreateTemp("", "tash-screen-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	_ = tmpFile.Close()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	args := []string{"action", "dump-screen", tmpPath}
+	if full {
+		args = []string{"action", "dump-screen", "--full", tmpPath}
+	}
+
+	cmd := exec.Command("zellij", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("zellij dump-screen: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	content, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("read screen dump: %w", err)
+	}
+
+	return string(content), nil
+}
+
+// parseScreenDump strips ANSI codes and trailing blank lines, then returns
+// the last N lines from the dump.
+func parseScreenDump(content string, lines int) string {
+	content = stripANSI(content)
+
+	// Split and trim trailing empty lines
+	allLines := strings.Split(content, "\n")
+	for len(allLines) > 0 && strings.TrimSpace(allLines[len(allLines)-1]) == "" {
+		allLines = allLines[:len(allLines)-1]
+	}
+
+	if len(allLines) == 0 {
+		return ""
+	}
+
+	// Take last N lines
+	if lines < len(allLines) {
+		allLines = allLines[len(allLines)-lines:]
+	}
+
+	return strings.Join(allLines, "\n")
+}
+
+// stripANSI removes ANSI escape sequences from text.
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+// countNonEmpty returns the number of non-whitespace-only lines in a string.
+func countNonEmpty(content string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// initialScreenContext captures a small initial screen context (last 20 lines)
+// to inject at query start, giving the AI visibility into what's on screen.
+// Returns empty string if screen capture is unavailable or disabled.
+func initialScreenContext(cfg *data.Config) string {
+	if !cfg.Behavior.ScreenCapture {
+		return ""
+	}
+
+	if os.Getenv("ZELLIJ") == "" {
+		return ""
+	}
+
+	content, err := zellijDumpScreen(false)
+	if err != nil {
+		slog.Debug("initial screen capture skipped", "error", err)
+		return ""
+	}
+
+	parsed := parseScreenDump(content, 20)
+	if parsed == "" {
+		return ""
+	}
+
+	return "Terminal screen (last 20 lines):\n" + parsed
+}

--- a/internal/query/screen_test.go
+++ b/internal/query/screen_test.go
@@ -1,0 +1,337 @@
+package query
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/renjfk/tash/internal/ai"
+	"github.com/renjfk/tash/internal/data"
+)
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"color code", "\x1b[31mred\x1b[0m", "red"},
+		{"bold", "\x1b[1mbold\x1b[0m", "bold"},
+		{"multiple codes", "\x1b[1;32mgreen bold\x1b[0m normal", "green bold normal"},
+		{"cursor movement", "\x1b[2Jhello", "hello"},
+		{"osc title", "\x1b]0;title\x07text", "text"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripANSI(tt.input)
+			if got != tt.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseScreenDump(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		lines   int
+		want    string
+	}{
+		{
+			"basic last 3 lines",
+			"line1\nline2\nline3\nline4\nline5\n",
+			3,
+			"line3\nline4\nline5",
+		},
+		{
+			"fewer lines than requested",
+			"line1\nline2\n",
+			10,
+			"line1\nline2",
+		},
+		{
+			"strips trailing blanks",
+			"line1\nline2\n\n\n\n",
+			5,
+			"line1\nline2",
+		},
+		{
+			"empty content",
+			"",
+			5,
+			"",
+		},
+		{
+			"only whitespace",
+			"   \n  \n\n",
+			5,
+			"",
+		},
+		{
+			"strips ANSI then returns tail",
+			"\x1b[31mred\x1b[0m\nplain\n\x1b[1mbold\x1b[0m\n",
+			2,
+			"plain\nbold",
+		},
+		{
+			"single line",
+			"only line\n",
+			1,
+			"only line",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseScreenDump(tt.content, tt.lines)
+			if got != tt.want {
+				t.Errorf("parseScreenDump() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountNonEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"mixed", "hello\n\nworld\n  \nfoo\n", 3},
+		{"all empty", "\n\n\n", 0},
+		{"no newline", "hello", 1},
+		{"empty string", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countNonEmpty(tt.content)
+			if got != tt.want {
+				t.Errorf("countNonEmpty() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCaptureScreen_Disabled(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = false
+
+	got := captureScreen(cfg, 20)
+	if !strings.Contains(got, "disabled") {
+		t.Errorf("expected disabled message, got %q", got)
+	}
+}
+
+func TestCaptureScreen_NoZellij(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+
+	t.Setenv("ZELLIJ", "")
+
+	got := captureScreen(cfg, 20)
+	if !strings.Contains(got, "Not running inside Zellij") {
+		t.Errorf("expected no-zellij message, got %q", got)
+	}
+}
+
+func TestInitialScreenContext_Disabled(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = false
+
+	got := initialScreenContext(cfg)
+	if got != "" {
+		t.Errorf("expected empty when disabled, got %q", got)
+	}
+}
+
+func TestInitialScreenContext_NoZellij(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+
+	t.Setenv("ZELLIJ", "")
+
+	got := initialScreenContext(cfg)
+	if got != "" {
+		t.Errorf("expected empty without zellij, got %q", got)
+	}
+}
+
+func TestHandleResponses_ScreenRequest(t *testing.T) {
+	convo := data.NewConversation()
+	constraints := []string{}
+	retryReason := ""
+	stepsRemaining := 0
+
+	responses := []ai.TashResponse{
+		{Type: "screen", Lines: 30},
+	}
+
+	cfg := data.DefaultConfig()
+	cfg.SetDataDir(t.TempDir())
+	cfg.Behavior.ScreenCapture = true
+	usage := ai.Usage{}
+
+	// Without ZELLIJ set, screen capture returns a graceful message
+	t.Setenv("ZELLIJ", "")
+
+	_, action := handleResponses(responses, cfg, convo, nil, &constraints, false, &retryReason, &stepsRemaining, "req1", usage)
+
+	if action != actionRetry {
+		t.Errorf("expected actionRetry for screen request, got %d", action)
+	}
+	if retryReason != "Reading terminal" {
+		t.Errorf("expected retry reason 'Reading terminal', got %q", retryReason)
+	}
+	if len(constraints) == 0 {
+		t.Error("expected constraints to be populated with screen result")
+	}
+	// Should contain the graceful no-zellij message
+	if !strings.Contains(constraints[0], "Not running inside Zellij") {
+		t.Errorf("expected no-zellij constraint, got %q", constraints[0])
+	}
+}
+
+func TestHandleResponses_ScreenSkipWhenCapped(t *testing.T) {
+	convo := data.NewConversation()
+	constraints := []string{}
+	retryReason := ""
+	stepsRemaining := 0
+
+	responses := []ai.TashResponse{
+		{Type: "screen", Lines: 20},
+	}
+
+	cfg := data.DefaultConfig()
+	cfg.SetDataDir(t.TempDir())
+	usage := ai.Usage{}
+
+	// skipToolCalls=true
+	_, action := handleResponses(responses, cfg, convo, nil, &constraints, true, &retryReason, &stepsRemaining, "req1", usage)
+
+	if action != actionNothing {
+		t.Errorf("expected actionNothing when tool calls capped, got %d", action)
+	}
+}
+
+func TestHasTerminalResponse_ScreenIsNotTerminal(t *testing.T) {
+	responses := []ai.TashResponse{{Type: "screen"}}
+	if hasTerminalResponse(responses) {
+		t.Error("screen should not be a terminal response")
+	}
+}
+
+func TestCaptureScreen_DefaultLines(t *testing.T) {
+	// Verify that lines=0 defaults to 20 (tested via the no-zellij path
+	// which still exercises the lines normalization)
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+	t.Setenv("ZELLIJ", "")
+
+	got := captureScreen(cfg, 0)
+	if !strings.Contains(got, "Not running inside Zellij") {
+		t.Errorf("expected no-zellij message even with lines=0, got %q", got)
+	}
+}
+
+func TestCaptureScreen_MaxLinesCap(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+	cfg.Behavior.ScreenCaptureMaxLines = 50
+	t.Setenv("ZELLIJ", "")
+
+	// Requesting more than max should be capped (no crash)
+	got := captureScreen(cfg, 1000)
+	if !strings.Contains(got, "Not running inside Zellij") {
+		t.Errorf("expected no-zellij message, got %q", got)
+	}
+}
+
+func TestParseResponse_ScreenType(t *testing.T) {
+	raw := `{"type": "screen", "lines": 50}`
+	responses, err := ai.ParseResponse(raw)
+	if err != nil {
+		t.Fatalf("ParseResponse: %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(responses))
+	}
+	if responses[0].Type != "screen" {
+		t.Errorf("expected type screen, got %q", responses[0].Type)
+	}
+	if responses[0].Lines != 50 {
+		t.Errorf("expected 50 lines, got %d", responses[0].Lines)
+	}
+}
+
+// Verify that the screen response type is advertised in the system prompt
+func TestSystemPrompt_ContainsScreenTool(t *testing.T) {
+	if !strings.Contains(ai.SystemPrompt, `"type": "screen"`) {
+		t.Error("SystemPrompt should advertise the screen tool")
+	}
+}
+
+func TestCaptureScreen_ZellijNotInstalled(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+
+	// Set ZELLIJ but ensure zellij binary isn't available (it likely isn't in CI)
+	t.Setenv("ZELLIJ", "1")
+	t.Setenv("PATH", t.TempDir()) // empty PATH so zellij won't be found
+
+	got := captureScreen(cfg, 20)
+	if !strings.Contains(got, "Screen capture failed") {
+		// May also succeed if zellij happens to be installed — either way, should not panic
+		if !strings.Contains(got, "Terminal screen output") {
+			t.Errorf("expected either failure message or screen output, got %q", got)
+		}
+	}
+}
+
+// TestInitialScreenContext_ZellijNotInstalled verifies graceful handling when
+// ZELLIJ env is set but the binary is missing.
+func TestInitialScreenContext_ZellijNotInstalled(t *testing.T) {
+	cfg := data.DefaultConfig()
+	cfg.Behavior.ScreenCapture = true
+
+	t.Setenv("ZELLIJ", "1")
+	t.Setenv("PATH", t.TempDir())
+
+	// Should return empty (graceful) rather than panic
+	got := initialScreenContext(cfg)
+	_ = got // just checking it doesn't panic
+}
+
+func TestHandleResponses_ScreenDisabled(t *testing.T) {
+	convo := data.NewConversation()
+	constraints := []string{}
+	retryReason := ""
+	stepsRemaining := 0
+
+	responses := []ai.TashResponse{
+		{Type: "screen", Lines: 20},
+	}
+
+	cfg := data.DefaultConfig()
+	cfg.SetDataDir(t.TempDir())
+	cfg.Behavior.ScreenCapture = false
+	usage := ai.Usage{}
+
+	t.Setenv("ZELLIJ", "1")
+
+	// Redirect stderr to suppress output
+	old := os.Stderr
+	os.Stderr, _ = os.Open(os.DevNull)
+	defer func() { os.Stderr = old }()
+
+	_, action := handleResponses(responses, cfg, convo, nil, &constraints, false, &retryReason, &stepsRemaining, "req1", usage)
+
+	if action != actionRetry {
+		t.Errorf("expected actionRetry, got %d", action)
+	}
+	// Constraint should mention disabled
+	if len(constraints) == 0 || !strings.Contains(constraints[0], "disabled") {
+		t.Errorf("expected disabled constraint, got %v", constraints)
+	}
+}


### PR DESCRIPTION
## Summary

- Add agentic `screen` tool that captures Zellij pane output via `dump-screen`, with ANSI stripping and configurable line limits
- Inject initial screen context (last 20 lines) automatically on query start when running inside Zellij
- Gate behind `behavior.screen_capture` (default true) and `behavior.screen_capture_max_lines` (default 200) config flags
- AI can request more lines via `{"type": "screen", "lines": N}`, auto-escalating to full scrollback when needed

Closes #2