### PR TITLE
feat: render TUI with compatible characters when TTY lacks Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ behavior:
   max_retries: 3
   max_memories: 50
   auto_intercept: true
+  screen_capture: true
+  screen_capture_max_lines: 200
 
 profile:
   rebuild_interval: 3600
@@ -131,19 +133,27 @@ theme:
   name: "solarized"
   color: ""
 
+terminal:
+  ascii: false
+  color: "auto"
+
 log_level: "info"
 ```
 
-| Field                      | Description                                                    |
-|----------------------------|----------------------------------------------------------------|
-| `model.name`               | Any model supported by the configured endpoint                 |
-| `model.endpoint`           | Any OpenAI-compatible API (Anthropic, OpenAI, Ollama, etc.)    |
-| `model.api_key_env`        | Environment variable holding the API key                       |
-| `behavior.auto_intercept`  | Automatically intercept failed natural language commands       |
-| `behavior.max_memories`    | Durable facts the AI remembers about you across sessions       |
-| `profile.rebuild_interval` | Seconds between background profile rebuilds from shell history |
-| `theme.name`               | Preset theme (see below)                                       |
-| `theme.color`              | Custom hex color, overrides theme name                         |
+| Field                               | Description                                                    |
+|-------------------------------------|----------------------------------------------------------------|
+| `model.name`                        | Any model supported by the configured endpoint                 |
+| `model.endpoint`                    | Any OpenAI-compatible API (Anthropic, OpenAI, Ollama, etc.)    |
+| `model.api_key_env`                 | Environment variable holding the API key                       |
+| `behavior.auto_intercept`           | Automatically intercept failed natural language commands       |
+| `behavior.max_memories`             | Durable facts the AI remembers about you across sessions       |
+| `behavior.screen_capture`           | Capture terminal screen content for AI context                 |
+| `behavior.screen_capture_max_lines` | Maximum lines to capture from terminal screen                  |
+| `profile.rebuild_interval`          | Seconds between background profile rebuilds from shell history |
+| `theme.name`                        | Preset theme (see below)                                       |
+| `theme.color`                       | Custom hex color, overrides theme name                         |
+| `terminal.ascii`                    | Use ASCII-only characters for limited Unicode terminals        |
+| `terminal.color`                    | Color profile override: `auto`, `256`, `16`, `none`            |
 
 Available themes: `solarized` `gruvbox` `nord` `dracula` `monokai` `catppuccin`
 `tokyo-night` `rose-pine` `kanagawa` `everforest` `onedark` `nightfox`

--- a/cmd/tash/main.go
+++ b/cmd/tash/main.go
@@ -52,6 +52,7 @@ func main() {
 	closeLog := data.InitLogger(cfg.DataDir(), cfg.LogLevel)
 	defer closeLog()
 
+	tui.ApplyCompat(cfg.Terminal.ASCII, cfg.Terminal.Color)
 	tui.ApplyTheme(cfg.Theme.Name, cfg.Theme.Color)
 
 	switch os.Args[1] {
@@ -378,7 +379,8 @@ func runGreet() {
 	seed := int(time.Now().UnixNano() & 0x7fffffff)
 	h1 := tui.FaceHash(seed)
 	h2 := tui.FaceHash(seed + 31)
-	f := tui.Faces[h1%len(tui.Faces)]
+	faces := tui.Faces()
+	f := faces[h1%len(faces)]
 	msg := greetMessages[h2%len(greetMessages)]
 	accent := tui.ActiveTheme().Accent
 	face := lipgloss.NewStyle().Foreground(accent).Render(f)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -24,7 +25,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Behavior BehaviorConfig `yaml:"behavior"`
 	Profile  ProfileConfig  `yaml:"profile"`
 	Theme    ThemeConfig    `yaml:"theme"`
+	Terminal TerminalConfig `yaml:"terminal"`
 	LogLevel string         `yaml:"log_level"`
 	dataDir  string
 }
@@ -22,6 +23,12 @@ type Config struct {
 type ThemeConfig struct {
 	Name  string `yaml:"name"`  // preset name: blue, green, purple, orange, pink, red, cyan
 	Color string `yaml:"color"` // custom hex color (e.g. "#FF4085"), overrides name
+}
+
+// TerminalConfig holds terminal compatibility settings.
+type TerminalConfig struct {
+	ASCII bool   `yaml:"ascii"` // use ASCII-only characters when true
+	Color string `yaml:"color"` // color profile override: auto, 256, 16, none
 }
 
 // ModelConfig holds AI model settings.
@@ -65,6 +72,9 @@ func DefaultConfig() *Config {
 		},
 		Theme: ThemeConfig{
 			Name: "solarized",
+		},
+		Terminal: TerminalConfig{
+			Color: "auto",
 		},
 		LogLevel: "info",
 		Profile: ProfileConfig{

--- a/internal/data/config_test.go
+++ b/internal/data/config_test.go
@@ -42,6 +42,12 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Profile.RebuildInterval != 3600 {
 		t.Errorf("expected 3600, got %d", cfg.Profile.RebuildInterval)
 	}
+	if cfg.Terminal.ASCII {
+		t.Error("expected terminal.ascii false by default")
+	}
+	if cfg.Terminal.Color != "auto" {
+		t.Errorf("expected terminal.color auto, got %q", cfg.Terminal.Color)
+	}
 }
 
 func TestDataDir(t *testing.T) {

--- a/internal/tui/compat.go
+++ b/internal/tui/compat.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// charSet holds the character mappings for spinner dots and companion faces.
+// The active set is selected at startup based on terminal.ascii config.
+type charSet struct {
+	ActiveDot   string
+	InactiveDot string
+	Faces       []string
+	Glances     []string
+	Blink       string
+	Sleepy      string
+	Default     string
+}
+
+var unicodeChars = charSet{
+	ActiveDot:   "■",
+	InactiveDot: "⬝",
+	Faces: []string{
+		"(◕‿◕)",
+		"(◐‿◐)",
+		"(◑‿◑)",
+		"(◔‿◔)",
+	},
+	Glances: []string{
+		"(◐‿◐)",
+		"(◑‿◑)",
+		"(◔‿◔)",
+	},
+	Blink:   "(-‿-)",
+	Sleepy:  "(◡‿◡)",
+	Default: "(◕‿◕)",
+}
+
+var asciiChars = charSet{
+	ActiveDot:   "#",
+	InactiveDot: ".",
+	Faces: []string{
+		"(o_o)",
+		"(>_>)",
+		"(<_<)",
+		"(^_^)",
+	},
+	Glances: []string{
+		"(>_>)",
+		"(<_<)",
+		"(^_^)",
+	},
+	Blink:   "(-_-)",
+	Sleepy:  "(~_~)",
+	Default: "(o_o)",
+}
+
+// activeChars is set once at startup by ApplyCompat.
+var activeChars = &unicodeChars
+
+// ActiveChars returns the current character set.
+func ActiveChars() *charSet {
+	return activeChars
+}
+
+// ApplyCompat configures terminal compatibility: ASCII character set and
+// lipgloss color profile override. Call once at startup after loading config.
+func ApplyCompat(ascii bool, colorMode string) {
+	if ascii {
+		activeChars = &asciiChars
+	} else {
+		activeChars = &unicodeChars
+	}
+
+	applyColorProfile(colorMode)
+}
+
+func applyColorProfile(mode string) {
+	var profile termenv.Profile
+
+	switch mode {
+	case "256":
+		profile = termenv.ANSI256
+	case "16":
+		profile = termenv.ANSI
+	case "none":
+		profile = termenv.Ascii
+	default:
+		// "auto" or unrecognized: leave lipgloss auto-detection in place
+		return
+	}
+
+	stderrRenderer.SetColorProfile(profile)
+	lipgloss.DefaultRenderer().SetColorProfile(profile)
+
+	// Re-render any styles that were already created so they pick up the new profile.
+	// faceStyle and phaseStyle are recomputed by ApplyTheme which runs after ApplyCompat,
+	// but the prompt styles (CmdStyle, etc.) were set at package init and use stderrRenderer.
+	// Re-creating them ensures they honour the forced profile.
+	CmdStyle = stderrRenderer.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	FailStyle = stderrRenderer.NewStyle().Foreground(lipgloss.Color("1"))
+	TraceStyle = stderrRenderer.NewStyle().Faint(true)
+	hintStyle = stderrRenderer.NewStyle().Faint(true)
+	stepStyle = stderrRenderer.NewStyle().Faint(true)
+	elapsedStyle = stderrRenderer.NewStyle().Faint(true)
+
+	// Also update the default renderer for styles created outside tui package
+	// (e.g. greet in main.go uses lipgloss.NewStyle())
+	lipgloss.SetDefaultRenderer(lipgloss.NewRenderer(os.Stderr, termenv.WithProfile(profile)))
+}

--- a/internal/tui/compat_test.go
+++ b/internal/tui/compat_test.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestApplyCompat_Unicode(t *testing.T) {
+	saved := activeChars
+	defer func() { activeChars = saved }()
+
+	ApplyCompat(false, "auto")
+
+	chars := ActiveChars()
+	if chars.ActiveDot != "■" {
+		t.Errorf("expected Unicode active dot, got %q", chars.ActiveDot)
+	}
+	if chars.InactiveDot != "⬝" {
+		t.Errorf("expected Unicode inactive dot, got %q", chars.InactiveDot)
+	}
+	if chars.Default != "(◕‿◕)" {
+		t.Errorf("expected Unicode default face, got %q", chars.Default)
+	}
+}
+
+func TestApplyCompat_ASCII(t *testing.T) {
+	saved := activeChars
+	defer func() { activeChars = saved }()
+
+	ApplyCompat(true, "auto")
+
+	chars := ActiveChars()
+	if chars.ActiveDot != "#" {
+		t.Errorf("expected ASCII active dot, got %q", chars.ActiveDot)
+	}
+	if chars.InactiveDot != "." {
+		t.Errorf("expected ASCII inactive dot, got %q", chars.InactiveDot)
+	}
+	if chars.Default != "(o_o)" {
+		t.Errorf("expected ASCII default face, got %q", chars.Default)
+	}
+	if chars.Blink != "(-_-)" {
+		t.Errorf("expected ASCII blink face, got %q", chars.Blink)
+	}
+	if chars.Sleepy != "(~_~)" {
+		t.Errorf("expected ASCII sleepy face, got %q", chars.Sleepy)
+	}
+}
+
+func TestApplyCompat_FacesMatchCharSet(t *testing.T) {
+	saved := activeChars
+	defer func() { activeChars = saved }()
+
+	ApplyCompat(false, "auto")
+	unicodeFaces := Faces()
+	if len(unicodeFaces) != 4 {
+		t.Errorf("expected 4 unicode faces, got %d", len(unicodeFaces))
+	}
+
+	ApplyCompat(true, "auto")
+	asciiFaces := Faces()
+	if len(asciiFaces) != 4 {
+		t.Errorf("expected 4 ascii faces, got %d", len(asciiFaces))
+	}
+
+	// ASCII faces should differ from unicode faces
+	if unicodeFaces[0] == asciiFaces[0] {
+		t.Error("expected different faces between unicode and ascii sets")
+	}
+}
+
+func TestApplyCompat_GlancesCount(t *testing.T) {
+	saved := activeChars
+	defer func() { activeChars = saved }()
+
+	ApplyCompat(true, "auto")
+	chars := ActiveChars()
+	if len(chars.Glances) != 3 {
+		t.Errorf("expected 3 ascii glances, got %d", len(chars.Glances))
+	}
+
+	ApplyCompat(false, "auto")
+	chars = ActiveChars()
+	if len(chars.Glances) != 3 {
+		t.Errorf("expected 3 unicode glances, got %d", len(chars.Glances))
+	}
+}
+
+func TestFace_ASCIIMode(t *testing.T) {
+	savedChars := activeChars
+	savedSeed := faceSeed
+	defer func() {
+		activeChars = savedChars
+		faceSeed = savedSeed
+	}()
+
+	ApplyCompat(true, "auto")
+	faceSeed = 42
+
+	asciiFaceSet := map[string]bool{
+		"(o_o)": true,
+		"(>_>)": true,
+		"(<_<)": true,
+		"(^_^)": true,
+		"(-_-)": true,
+		"(~_~)": true,
+	}
+
+	for i := 0; i < 250; i++ {
+		f := face(i)
+		if !asciiFaceSet[f] {
+			t.Errorf("face(%d) = %q, not in ASCII face set", i, f)
+		}
+	}
+}

--- a/internal/tui/spinner.go
+++ b/internal/tui/spinner.go
@@ -17,9 +17,6 @@ const (
 	holdEnd   = 9
 	holdStart = 30
 	interval  = 40 * time.Millisecond
-
-	activeChar   = "■"
-	inactiveChar = "⬝"
 )
 
 var (
@@ -28,18 +25,9 @@ var (
 	elapsedStyle = stderrRenderer.NewStyle().Faint(true)
 )
 
-// Faces is the shared set of tash companion faces used in greetings and spinner.
-var Faces = []string{
-	"(◕‿◕)", // default
-	"(◐‿◐)", // look right
-	"(◑‿◑)", // look left
-	"(◔‿◔)", // look up
-}
-
-var glances = []string{
-	"(◐‿◐)", // look right
-	"(◑‿◑)", // look left
-	"(◔‿◔)", // look up
+// Faces returns the shared set of tash companion faces used in greetings and spinner.
+func Faces() []string {
+	return activeChars.Faces
 }
 
 // faceSeed is set at process start so each invocation produces a different sequence.
@@ -59,6 +47,8 @@ func FaceHash(n int) int {
 // face returns the tash companion face based on a global frame counter.
 // Blinks at irregular intervals, changes expression every 1-3s, sleepy after ~8s.
 func face(frame int) string {
+	chars := activeChars
+
 	// Blink check — walk through variable-length blink intervals.
 	// Each interval is 30-80 frames (1.2-3.2s), blink lasts 3 frames (~120ms).
 	blinkPos := 0
@@ -67,7 +57,7 @@ func face(frame int) string {
 		h := FaceHash(blinkSeg*7 + faceSeed)
 		gap := 25 + h%25 // 25..49 frames between blinks (1-2s)
 		if frame >= blinkPos+gap && frame < blinkPos+gap+3 {
-			return "(-‿-)"
+			return chars.Blink
 		}
 		blinkPos += gap + 3
 		blinkSeg++
@@ -75,7 +65,7 @@ func face(frame int) string {
 
 	// After ~8s go sleepy
 	if frame > 200 {
-		return "(◡‿◡)"
+		return chars.Sleepy
 	}
 
 	// Expression changes — walk through variable-length segments.
@@ -86,17 +76,17 @@ func face(frame int) string {
 		h := FaceHash(seg + faceSeed)
 		segLen := 25 + h%50
 		if frame < pos+segLen {
-			idx := (h / 50) % (len(glances) + 1)
-			if idx < len(glances) {
-				return glances[idx]
+			idx := (h / 50) % (len(chars.Glances) + 1)
+			if idx < len(chars.Glances) {
+				return chars.Glances[idx]
 			}
-			return "(◕‿◕)"
+			return chars.Default
 		}
 		pos += segLen
 		seg++
 	}
 
-	return "(◕‿◕)"
+	return chars.Default
 }
 
 // phaseMsg updates the spinner phase label.
@@ -289,12 +279,13 @@ func (m spinnerModel) View() string {
 	absFrame := m.cycle*totalFrames() + m.frame
 	b.WriteString(faceStyle.Render(face(absFrame)))
 	b.WriteString(" ")
+	chars := activeChars
 	for i := 0; i < dotCount; i++ {
 		idx := colorIndex(i, s)
 		if idx >= 0 && idx < trailLen {
-			b.WriteString(stderrRenderer.NewStyle().Foreground(lipgloss.Color(activeTheme.TrailHex[idx])).Render(activeChar))
+			b.WriteString(stderrRenderer.NewStyle().Foreground(lipgloss.Color(activeTheme.TrailHex[idx])).Render(chars.ActiveDot))
 		} else {
-			b.WriteString(stderrRenderer.NewStyle().Foreground(inactiveCol).Render(inactiveChar))
+			b.WriteString(stderrRenderer.NewStyle().Foreground(inactiveCol).Render(chars.InactiveDot))
 		}
 	}
 

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -18,15 +18,18 @@ func TestFace_DefaultExpression(t *testing.T) {
 	if f == "" {
 		t.Error("face(0) returned empty string")
 	}
-	// Should be one of the known faces
-	knownFaces := map[string]bool{
-		"(◕‿◕)": true,
-		"(◐‿◐)": true,
-		"(◑‿◑)": true,
-		"(◔‿◔)": true,
-		"(-‿-)": true,
-		"(◡‿◡)": true,
+	// Should be one of the known faces from active charset
+	chars := activeChars
+	knownFaces := make(map[string]bool)
+	for _, fc := range chars.Faces {
+		knownFaces[fc] = true
 	}
+	for _, fc := range chars.Glances {
+		knownFaces[fc] = true
+	}
+	knownFaces[chars.Blink] = true
+	knownFaces[chars.Sleepy] = true
+	knownFaces[chars.Default] = true
 	if !knownFaces[f] {
 		t.Errorf("face(0) returned unknown face: %q", f)
 	}
@@ -37,9 +40,10 @@ func TestFace_SleepyAfter200(t *testing.T) {
 	defer func() { faceSeed = old }()
 	faceSeed = 42
 
+	chars := activeChars
 	f := face(201)
 	// After frame 200, should return sleepy face unless in a blink
-	if f != "(◡‿◡)" && f != "(-‿-)" {
+	if f != chars.Sleepy && f != chars.Blink {
 		t.Errorf("face(201) = %q, expected sleepy or blink", f)
 	}
 }
@@ -49,10 +53,11 @@ func TestFace_BlinkDetection(t *testing.T) {
 	defer func() { faceSeed = old }()
 	faceSeed = 12345
 
+	chars := activeChars
 	// Scan first 200 frames, should find at least one blink
 	blinks := 0
 	for i := 0; i < 200; i++ {
-		if face(i) == "(-‿-)" {
+		if face(i) == chars.Blink {
 			blinks++
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `terminal` config section with `ascii` and `color` flags for terminals with limited Unicode or color support
- Define ASCII fallback character sets for spinner dots (`#`/`.`) and companion faces (`(o_o)`, `(>_>)`, `(-_-)`, etc.)
- Override lipgloss color profile when `terminal.color` is set to `256`, `16`, or `none`
- Update README config documentation with missing `screen_capture` fields and new `terminal` section

Closes #3